### PR TITLE
Redesign options page Presets and Settings tabs

### DIFF
--- a/src/js/components/options/PackageSettingsEditor.tsx
+++ b/src/js/components/options/PackageSettingsEditor.tsx
@@ -71,7 +71,7 @@ const PackageSettingsEditor = ({
         }
 
         return (
-            <div key={id} className="multi-param-input-row" style={{ display: 'flex', alignItems: 'center' }}>
+            <Box key={id} className="multi-param-input-row" sx={{ display: 'flex', alignItems: 'center' }}>
                 <TextField
                     sx={{ marginRight: '10px', flex: 1 }}
                     hiddenLabel
@@ -80,8 +80,9 @@ const PackageSettingsEditor = ({
                     value={label} onChange={e => updateParamLabel(e.target.value)}
                 />
                 <TextField
+                    sx={{ width: 72 }}
                     hiddenLabel
-                    placeholder="Delimeter"
+                    placeholder="e.g. ,"
                     size="small"
                     value={separator} onChange={e => updateParamSeparator(e.target.value)}
                 />
@@ -89,7 +90,7 @@ const PackageSettingsEditor = ({
                     sx={{ padding: '0', marginLeft: '10px' }} onClick={removeParam}>
                     <ClearIcon fontSize="inherit" />
                 </IconButton>
-            </div>
+            </Box>
         )
     })
 
@@ -116,7 +117,7 @@ const PackageSettingsEditor = ({
             updateUrlPatterns(newUrlPatterns)
         }
         return (
-            <div key={v.id} style={{ display: 'flex', marginTop: '10px', alignItems: 'center' }}>
+            <Box key={v.id} sx={{ display: 'flex', marginTop: '8px', alignItems: 'center' }}>
                 <TextField
                     sx={{ flex: '1' }}
                     hiddenLabel
@@ -127,7 +128,7 @@ const PackageSettingsEditor = ({
                     sx={{ padding: '0', marginLeft: '10px' }} onClick={removePattern}>
                     <ClearIcon fontSize="inherit" />
                 </IconButton>
-            </div>
+            </Box>
         )
     })
 
@@ -179,7 +180,7 @@ const PackageSettingsEditor = ({
             updateDomSelectors(newDomSelectors)
         }
         return (
-            <div key={v.id} style={{ display: 'flex', marginTop: '10px', alignItems: 'center' }}>
+            <Box key={v.id} sx={{ display: 'flex', marginTop: '8px', alignItems: 'center' }}>
                 <TextField
                     sx={{ flex: '1' }}
                     hiddenLabel
@@ -190,7 +191,7 @@ const PackageSettingsEditor = ({
                     sx={{ padding: '0', marginLeft: '10px' }} onClick={removeDomSelector}>
                     <ClearIcon fontSize="inherit" />
                 </IconButton>
-            </div>
+            </Box>
         )
     })
 
@@ -212,35 +213,59 @@ const PackageSettingsEditor = ({
 
     return (
         <div>
-            <Typography fontWeight="bold" padding={1}>Url patterns</Typography>
-            <Box>
-                {patternsInput}
-                <Button sx={{ marginTop: '10px' }} onClick={addNewUrlPattern}
-                    variant="text" startIcon={<AddIcon />}>Add</Button>
+            <Typography fontWeight="bold" sx={{ paddingY: 0.5 }}>Activation conditions</Typography>
+            <Typography variant="body2" sx={{ opacity: 0.7, paddingBottom: 1 }}>
+                Where this package&apos;s presets are available. A package activates when any URL pattern matches and all DOM selectors are present.
+            </Typography>
+
+            <Box sx={{ paddingLeft: 1 }}>
+                <Typography variant="subtitle2" sx={{ opacity: 0.85, paddingTop: 1 }}>Url patterns</Typography>
+                <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                    Match-pattern syntax (e.g. https://example.com/*).
+                </Typography>
+                <Box>
+                    {patternsInput}
+                    <Button sx={{ marginTop: '8px' }} onClick={addNewUrlPattern}
+                        variant="text" startIcon={<AddIcon />}>Add</Button>
+                </Box>
+
+                <Typography variant="subtitle2" sx={{ opacity: 0.85, paddingTop: 1.5 }}>Dom selectors</Typography>
+                <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                    Optional. CSS selectors that must exist on the page for the package to activate.
+                </Typography>
+                <Box>
+                    {domSelectorsInput}
+                    <Button sx={{ marginTop: '8px' }} onClick={addNewDomSelector}
+                        variant="text" startIcon={<AddIcon />}>Add</Button>
+                </Box>
             </Box>
-            <Divider sx={{ margin: '15px 0' }} />
-            <Typography fontWeight="bold" padding={1}>Dom selectors</Typography>
+
+            <Divider sx={{ margin: '12px 0' }} />
+            <Typography fontWeight="bold" sx={{ paddingY: 0.5 }}>Params with delimiter</Typography>
+            <Typography variant="body2" sx={{ opacity: 0.7, paddingBottom: 1 }}>
+                Params whose values should be treated as multi-value (e.g. comma-separated tags).
+            </Typography>
             <Box>
-                {domSelectorsInput}
-                <Button sx={{ marginTop: '10px' }} onClick={addNewDomSelector}
-                    variant="text" startIcon={<AddIcon />}>Add</Button>
-            </Box>
-            <Divider sx={{ margin: '15px 0' }} />
-            <Typography fontWeight="bold" padding={1}>Params with delimiter</Typography>
-            <Box>
+                {paramsWithDelimiter.length > 0 && (
+                    <Box sx={{ display: 'flex', alignItems: 'center', paddingTop: '4px' }}>
+                        <Typography variant="caption" sx={{ flex: 1, marginRight: '10px', opacity: 0.7 }}>Param key</Typography>
+                        <Typography variant="caption" sx={{ width: 72, opacity: 0.7 }}>Delimiter</Typography>
+                        <Box sx={{ width: 24, marginLeft: '10px' }} />
+                    </Box>
+                )}
                 {paramsItems}
-                <Button sx={{ marginTop: '10px' }} onClick={addNewMultiParam}
+                <Button sx={{ marginTop: '8px' }} onClick={addNewMultiParam}
                     variant="text" startIcon={<AddIcon />}>Add</Button>
             </Box>
-            <Divider sx={{ margin: '15px 0' }} />
-            <Typography fontWeight="bold" padding={1}>Param history</Typography>
+            <Divider sx={{ margin: '12px 0' }} />
+            <Typography fontWeight="bold" sx={{ paddingY: 0.5 }}>Param history</Typography>
             <Box sx={{ paddingLeft: 1 }}>
                 <Typography variant="body2" sx={{ opacity: 0.7 }}>
                     {paramHistoryCount === 0 ? 'No entries yet' : `${paramHistoryCount} entries`}
                 </Typography>
                 <Button
                     color="warning"
-                    sx={{ marginTop: '10px' }}
+                    sx={{ marginTop: '8px' }}
                     disabled={paramHistoryCount === 0}
                     onClick={openClearHistoryDialog}
                     variant="text"
@@ -264,7 +289,7 @@ const PackageSettingsEditor = ({
                     </DialogActions>
                 </Dialog>
             </Box>
-            <Divider sx={{ margin: '15px 0' }} />
+            <Divider sx={{ margin: '12px 0' }} />
             <div>
                 <Button sx={{ marginTop: '10px' }} onClick={() => addPackageWithSameSettings()}
                     variant="text">Add package with same settings</Button>

--- a/src/js/components/options/PackageSettingsEditor.tsx
+++ b/src/js/components/options/PackageSettingsEditor.tsx
@@ -215,7 +215,7 @@ const PackageSettingsEditor = ({
         <div>
             <Typography fontWeight="bold" sx={{ paddingY: 0.5 }}>Activation conditions</Typography>
             <Typography variant="body2" sx={{ opacity: 0.7, paddingBottom: 1 }}>
-                Where this package&apos;s presets are available. A package activates when any URL pattern matches and all DOM selectors are present.
+                Where this package&apos;s presets are available. The package activates when any URL pattern matches, or when any DOM selector is present on the page.
             </Typography>
 
             <Box sx={{ paddingLeft: 1 }}>
@@ -231,7 +231,7 @@ const PackageSettingsEditor = ({
 
                 <Typography variant="subtitle2" sx={{ opacity: 0.85, paddingTop: 1.5 }}>Dom selectors</Typography>
                 <Typography variant="body2" sx={{ opacity: 0.7 }}>
-                    Optional. CSS selectors that must exist on the page for the package to activate.
+                    Optional. The package also activates if any of these selectors is present on the page.
                 </Typography>
                 <Box>
                     {domSelectorsInput}

--- a/src/js/components/options/PackageSettingsEditor.tsx
+++ b/src/js/components/options/PackageSettingsEditor.tsx
@@ -219,20 +219,24 @@ const PackageSettingsEditor = ({
             </Typography>
 
             <Box sx={{ paddingLeft: 1 }}>
-                <Typography variant="subtitle2" sx={{ opacity: 0.85, paddingTop: 1 }}>Url patterns</Typography>
-                <Typography variant="body2" sx={{ opacity: 0.7 }}>
-                    Match-pattern syntax (e.g. https://example.com/*).
-                </Typography>
+                <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, flexWrap: 'wrap', paddingTop: 1 }}>
+                    <Typography variant="subtitle2" sx={{ opacity: 0.85 }}>Url patterns</Typography>
+                    <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                        Match-pattern syntax (e.g. https://example.com/*).
+                    </Typography>
+                </Box>
                 <Box>
                     {patternsInput}
                     <Button sx={{ marginTop: '8px' }} onClick={addNewUrlPattern}
                         variant="text" startIcon={<AddIcon />}>Add</Button>
                 </Box>
 
-                <Typography variant="subtitle2" sx={{ opacity: 0.85, paddingTop: 1.5 }}>Dom selectors</Typography>
-                <Typography variant="body2" sx={{ opacity: 0.7 }}>
-                    Optional. The package also activates if any of these selectors is present on the page.
-                </Typography>
+                <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, flexWrap: 'wrap', paddingTop: 1.5 }}>
+                    <Typography variant="subtitle2" sx={{ opacity: 0.85 }}>Dom selectors</Typography>
+                    <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                        Optional. Activates the package if any selector matches.
+                    </Typography>
+                </Box>
                 <Box>
                     {domSelectorsInput}
                     <Button sx={{ marginTop: '8px' }} onClick={addNewDomSelector}

--- a/src/js/components/options/PresetsEditor.tsx
+++ b/src/js/components/options/PresetsEditor.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
 import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { uuidv4 } from '../../utils/utils';
 import { SettingsPackage, EditorStore, SearchParamsEntries } from '../../types/types';
@@ -46,6 +48,8 @@ const PresetsEditor = ({ packageKey, presets, updatePackagePreset }: PresetsEdit
             updatePackagePreset(packageKey, newPresets)
         }
 
+        const hasEntries = presetData.entries.length > 0
+
         return (
             <Paper key={presetKey} elevation={2} className="preset-item">
                 <div className="preset-name-wrapper">
@@ -59,7 +63,16 @@ const PresetsEditor = ({ packageKey, presets, updatePackagePreset }: PresetsEdit
                         <DeleteIcon fontSize="inherit" />
                     </IconButton>
                 </div>
-                <SearchParams entries={presetData.entries} setEntries={updatePresetEntries} paramsWithDelimiter={{}} />
+                <Box>
+                    {hasEntries && (
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                            <Typography variant="caption" sx={{ flex: 1, opacity: 0.7 }}>Param key</Typography>
+                            <Typography variant="caption" sx={{ flex: 2, opacity: 0.7 }}>Value</Typography>
+                            <Box sx={{ flex: '0 0 28px' }} />
+                        </Box>
+                    )}
+                    <SearchParams entries={presetData.entries} setEntries={updatePresetEntries} paramsWithDelimiter={{}} />
+                </Box>
             </Paper>
         )
     })
@@ -77,6 +90,9 @@ const PresetsEditor = ({ packageKey, presets, updatePackagePreset }: PresetsEdit
 
     return (
         <div>
+            <Typography variant="body2" sx={{ opacity: 0.7, paddingBottom: 1 }}>
+                A preset is a named bundle of URL params. Apply it from the popup to set all params in one click. Type into the empty row at the bottom of a preset to add a new param.
+            </Typography>
             {presetsItems}
             <Button sx={{ marginTop: '10px' }} onClick={addNewPreset}
                 variant="text">Add Preset</Button>

--- a/src/js/components/options/PresetsEditor.tsx
+++ b/src/js/components/options/PresetsEditor.tsx
@@ -91,7 +91,7 @@ const PresetsEditor = ({ packageKey, presets, updatePackagePreset }: PresetsEdit
     return (
         <div>
             <Typography variant="body2" sx={{ opacity: 0.7, paddingBottom: 1 }}>
-                A preset is a named bundle of URL params. Apply it from the popup to set all params in one click. Type into the empty row at the bottom of a preset to add a new param.
+                A preset is a named bundle of URL params. Apply it from the popup to set all params in one click.
             </Typography>
             {presetsItems}
             <Button sx={{ marginTop: '10px' }} onClick={addNewPreset}

--- a/src/js/components/options/Settings.scss
+++ b/src/js/components/options/Settings.scss
@@ -6,13 +6,21 @@ body {
     display: flex;
     flex-direction: column;
     gap: 20px;
-
+    max-width: 760px;
+    margin: 0 auto;
 }
 
-.preset-item,
 .package-item {
     margin: 10px 0;
     padding: 20px;
+}
+
+.preset-item {
+    margin: 8px 0;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
 }
 
 .package-name-wrapper {
@@ -34,7 +42,7 @@ body {
 }
 
 .multi-param-input-row {
-    margin-top: 10px;
+    margin-top: 8px;
 }
 
 .multi-param-input-key {
@@ -45,12 +53,6 @@ body {
     display: flex;
     gap: 10px;
     align-items: center;
-}
-
-.preset-item {
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
 }
 
 .package-name-view {

--- a/src/js/components/popup/UseViewerStoreContext.tsx
+++ b/src/js/components/popup/UseViewerStoreContext.tsx
@@ -34,7 +34,6 @@ const UseViewerStoreContext = (props: PropsWithChildren<{ currentTabUrl: string 
         return acc
     }, {}))
 
-    // Uncaught (in promise) Error: Could not establish connection. Receiving end does not exist.
     useEffect(() => {
         const isRunInChromeExtension = chrome.tabs
         const messageListener = (message: DomSelectorResultMessage) => {
@@ -48,7 +47,8 @@ const UseViewerStoreContext = (props: PropsWithChildren<{ currentTabUrl: string 
             chrome.tabs.query({ active: true, currentWindow: true }, (tabs: chrome.tabs.Tab[]) => {
                 if (tabs[0]?.id) {
                     const message: DomSelectorRequestMessage = { type: 'DOM_SELECTOR_REQUEST', domSelectors };
-                    chrome.tabs.sendMessage(tabs[0].id, message);
+                    // No content script in tabs that predate the extension load, or on chrome:// URLs.
+                    chrome.tabs.sendMessage(tabs[0].id, message).catch(() => { });
                 }
             });
 


### PR DESCRIPTION
## Summary

- **Page-level layout**: cap `.settings-pages` at 760px centered so the AppBar, package accordions, tabs, and content all share one column instead of sprawling on wide monitors.
- **Settings tab**: group URL patterns + DOM selectors under a new **Activation conditions** heading with one-line subsection helpers; clarify the activation logic (OR between URL patterns and DOM selectors); add **Param key / Delimiter** column headers; shrink the delimiter input to 72px; tighten section paddings, dividers, and row gaps.
- **Presets tab**: add a tab-level helper sentence explaining what a preset is, and **Param key / Value** column headers above each preset's `<SearchParams>`. The shared `SearchParams` component is left untouched so the popup is unaffected.
- **Drive-by**: catch the `chrome.tabs.sendMessage` rejection in `UseViewerStoreContext` for tabs without a content script (chrome:// URLs and tabs that predate the extension load).

## Test plan

- [ ] Reload the extension and open the options page; confirm the AppBar, accordions, and tabs share the centered ~760px column.
- [ ] **Settings tab** — open a package, verify each section's helper text, the `Param key` / `Delimiter` column header (only with ≥1 row), and that adding/editing/deleting URL patterns, DOM selectors, and Params-with-delimiter entries persist across reload.
- [ ] **Presets tab** — verify the tab-level helper, the `Param key` / `Value` column header (only when a preset has ≥1 entry), and that adding/renaming/deleting presets and params still works.
- [ ] **Popup regression** — open the popup on a page where any preset matches; confirm the popup `SearchParams` rows render unchanged (no width caps or extra headers leaked from the options-only changes).
- [ ] `yarn test` passes.