### PR TITLE
Add themed scrollbar to autocomplete dropdowns

### DIFF
--- a/src/js/components/common/FreeSoloTags.tsx
+++ b/src/js/components/common/FreeSoloTags.tsx
@@ -3,6 +3,7 @@ import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
 import type { Theme } from '@mui/material/styles';
 import type { SxProps } from "@mui/system";
+import { autocompleteListboxSx } from "./autocompleteListboxSx";
 
 export type FreeSoloTagsProps = {
     values: Array<string>,
@@ -37,7 +38,7 @@ const FreeSoloTags = ({ values, onChange, sx, className, placeholderText, limitT
             onChange={onChangeHandler}
             getOptionLabel={(option) => option}
             isOptionEqualToValue={(option, value) => option === value}
-            ListboxProps={{ sx: { maxHeight: '340px' } }}
+            ListboxProps={{ sx: autocompleteListboxSx }}
 
             renderInput={(params) => (
                 <TextField hiddenLabel={true} {...params} size="small" placeholder={placeholderText} autoFocus={autoFocus} onKeyUp={onKeyUp} />

--- a/src/js/components/common/MuiTags.tsx
+++ b/src/js/components/common/MuiTags.tsx
@@ -9,6 +9,7 @@ import { toTrueObj } from "../../utils/arrayUtils";
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import type { SxProps } from "@mui/system";
+import { autocompleteListboxSx } from "./autocompleteListboxSx";
 
 export type TagsItem = { value: string; label: string; }
 
@@ -58,7 +59,7 @@ const Tags = ({ selected, suggestions, placeholderText, className, onAdd, onDele
             getOptionLabel={(option) => option.label}
             isOptionEqualToValue={(option, value) => option.value === value.value}
             value={selected}
-            ListboxProps={{ sx: { maxHeight: '340px', backgroundColor: (theme) => theme.palette.background.paper, color: (theme) => theme.palette.text.primary } }}
+            ListboxProps={{ sx: autocompleteListboxSx }}
             onChange={onChange}
             renderOption={(props, option, { selected }) => {
                 return (

--- a/src/js/components/common/SearchParams.tsx
+++ b/src/js/components/common/SearchParams.tsx
@@ -13,6 +13,7 @@ import usePrevious from "./usePrevious";
 import ParamWithDelimiterValueInput from "./ParamWithDelimiterValueInput";
 import ShortcutHint from "./ShortcutHint";
 import classNames from "classnames";
+import { autocompleteListboxSx } from "./autocompleteListboxSx";
 
 type SearchParamsProps = {
     entries: SearchParamsEntries
@@ -127,6 +128,7 @@ const SearchParams = ({ entries, setEntries, paramsWithDelimiter, className, sug
                 inputValue={key}
                 onInputChange={(_e, newInputValue) => updateCurrentEntryKey(newInputValue)}
                 onChange={(_e, newValue) => updateCurrentEntryKey(newValue ?? '')}
+                ListboxProps={{ sx: autocompleteListboxSx }}
                 renderInput={(params) => (
                     <TextField
                         {...params}
@@ -177,6 +179,7 @@ const SearchParams = ({ entries, setEntries, paramsWithDelimiter, className, sug
                 inputValue={value}
                 onInputChange={(_e, newInputValue) => updateCurrentEntryValue(newInputValue)}
                 onChange={(_e, newValue) => updateCurrentEntryValue(newValue ?? '')}
+                ListboxProps={{ sx: autocompleteListboxSx }}
                 renderInput={(params) => (
                     <TextField
                         {...params}

--- a/src/js/components/common/autocompleteListboxSx.ts
+++ b/src/js/components/common/autocompleteListboxSx.ts
@@ -1,0 +1,29 @@
+import type { Theme } from '@mui/material/styles';
+import type { SxProps } from '@mui/system';
+
+export const autocompleteListboxSx: SxProps<Theme> = {
+    maxHeight: '340px',
+    backgroundColor: (theme) => theme.palette.background.paper,
+    color: (theme) => theme.palette.text.primary,
+    '&::-webkit-scrollbar': {
+        width: 12,
+    },
+    '&::-webkit-scrollbar-track': {
+        background: 'transparent',
+    },
+    '&::-webkit-scrollbar-thumb': {
+        backgroundColor: (theme) =>
+            theme.palette.mode === 'dark'
+                ? 'rgba(255,255,255,0.18)'
+                : 'rgba(0,0,0,0.20)',
+        borderRadius: 6,
+        border: '3px solid transparent',
+        backgroundClip: 'padding-box',
+    },
+    '&::-webkit-scrollbar-thumb:hover': {
+        backgroundColor: (theme) =>
+            theme.palette.mode === 'dark'
+                ? 'rgba(255,255,255,0.32)'
+                : 'rgba(0,0,0,0.35)',
+    },
+};


### PR DESCRIPTION
## Summary
- Replace the native OS scrollbar in popup autocomplete listboxes with a thin, theme-aware webkit scrollbar that matches the dark/light palette
- Extract the listbox `sx` into a shared `autocompleteListboxSx` so the preset picker, free-solo tags, and search-params key/value inputs stay in sync
- Inset the thumb from the right edge via a transparent border + `background-clip: padding-box`

## Test plan
- [ ] `yarn build:dev`, reload unpacked extension
- [ ] Open popup with enough presets to overflow the dropdown — scrollbar is thin, themed, not flush against the right edge
- [ ] Switch to light theme in options page — thumb color flips to dark, still legible
- [ ] In search params row, trigger key autocomplete with many suggestions — same scrollbar
- [ ] Trigger value autocomplete (incl. delimited-values input) — same scrollbar