### PR TITLE
Commit autocomplete suggestion on Tab only, not on plain blur

### DIFF
--- a/src/js/components/common/FreeSoloTags.tsx
+++ b/src/js/components/common/FreeSoloTags.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEventHandler } from "react";
+import React, { KeyboardEventHandler, useRef, useState } from "react";
 import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
 import type { Theme } from '@mui/material/styles';
@@ -18,6 +18,9 @@ export type FreeSoloTagsProps = {
 }
 
 const FreeSoloTags = ({ values, onChange, sx, className, placeholderText, limitTags, onKeyUp, options = [], autoFocus = true }: FreeSoloTagsProps) => {
+    const highlightedRef = useRef<string | null>(null)
+    const [inputValue, setInputValue] = useState('')
+
     const onChangeHandler = (e: any, newValues: any) => {
         onChange(newValues as Array<string>)
     }
@@ -30,19 +33,48 @@ const FreeSoloTags = ({ values, onChange, sx, className, placeholderText, limitT
             limitTags={limitTags}
             disableCloseOnSelect
             filterSelectedOptions
-            autoSelect
             id="multiple-limit-tags"
             options={options}
             freeSolo={true}
             value={values}
+            inputValue={inputValue}
+            onInputChange={(_e, v) => setInputValue(v)}
             onChange={onChangeHandler}
+            onHighlightChange={(_e, option) => { highlightedRef.current = option }}
             getOptionLabel={(option) => option}
             isOptionEqualToValue={(option, value) => option === value}
             ListboxProps={{ sx: autocompleteListboxSx }}
 
-            renderInput={(params) => (
-                <TextField hiddenLabel={true} {...params} size="small" placeholder={placeholderText} autoFocus={autoFocus} onKeyUp={onKeyUp} />
-            )}
+            renderInput={(params) => {
+                const muiKeyDown = (params.inputProps as any).onKeyDown
+                return (
+                    <TextField
+                        hiddenLabel={true}
+                        {...params}
+                        size="small"
+                        placeholder={placeholderText}
+                        autoFocus={autoFocus}
+                        onKeyUp={onKeyUp}
+                        inputProps={{
+                            ...params.inputProps,
+                            onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+                                if (e.key === 'Tab') {
+                                    const highlighted = highlightedRef.current
+                                    const typed = inputValue.trim()
+                                    if (highlighted && !values.includes(highlighted)) {
+                                        onChange([...values, highlighted])
+                                        setInputValue('')
+                                    } else if (typed && !values.includes(typed)) {
+                                        onChange([...values, typed])
+                                        setInputValue('')
+                                    }
+                                }
+                                muiKeyDown?.(e)
+                            },
+                        }}
+                    />
+                )
+            }}
         />
     )
 }

--- a/src/js/components/common/MuiTags.tsx
+++ b/src/js/components/common/MuiTags.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 
 import Autocomplete from '@mui/material/Autocomplete';
 import Checkbox from '@mui/material/Checkbox';
@@ -24,6 +24,8 @@ export type TagsProps = {
 }
 
 const Tags = ({ selected, suggestions, placeholderText, className, onAdd, onDelete, sx }: TagsProps) => {
+    const highlightedRef = useRef<TagsItem | null>(null)
+
     const onChange = (e: any, newSelected: Array<{ value: string; label: string; }>) => {
         const prevTrueObj = toTrueObj(selected, (v) => v.value)
         const nextTrueObj = toTrueObj(newSelected, (v) => v.value)
@@ -53,7 +55,6 @@ const Tags = ({ selected, suggestions, placeholderText, className, onAdd, onDele
             className={className}
             multiple
             disableCloseOnSelect
-            autoSelect
             id="multiple-limit-tags"
             options={suggestions}
             getOptionLabel={(option) => option.label}
@@ -61,6 +62,7 @@ const Tags = ({ selected, suggestions, placeholderText, className, onAdd, onDele
             value={selected}
             ListboxProps={{ sx: autocompleteListboxSx }}
             onChange={onChange}
+            onHighlightChange={(_e, option) => { highlightedRef.current = option }}
             renderOption={(props, option, { selected }) => {
                 return (
                     <li {...props}>
@@ -74,19 +76,34 @@ const Tags = ({ selected, suggestions, placeholderText, className, onAdd, onDele
                     </li>
                 )
             }}
-            renderInput={(params) => (
-                <TextField
-                    hiddenLabel={true}
-                    {...params}
-                    placeholder={placeholderText}
-                    autoFocus={true}
-                    sx={{
-                        backgroundColor: (theme) => theme.palette.background.paper,
-                        color: (theme) => theme.palette.text.primary,
-                        borderRadius: 2,
-                    }}
-                />
-            )}
+            renderInput={(params) => {
+                const muiKeyDown = (params.inputProps as any).onKeyDown
+                return (
+                    <TextField
+                        hiddenLabel={true}
+                        {...params}
+                        placeholder={placeholderText}
+                        autoFocus={true}
+                        sx={{
+                            backgroundColor: (theme) => theme.palette.background.paper,
+                            color: (theme) => theme.palette.text.primary,
+                            borderRadius: 2,
+                        }}
+                        inputProps={{
+                            ...params.inputProps,
+                            onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+                                if (e.key === 'Tab') {
+                                    const highlighted = highlightedRef.current
+                                    if (highlighted && !selected.some(s => s.value === highlighted.value)) {
+                                        onChange(e, [...selected, highlighted])
+                                    }
+                                }
+                                muiKeyDown?.(e)
+                            },
+                        }}
+                    />
+                )
+            }}
         />
     )
 }

--- a/src/js/components/common/SearchParams.tsx
+++ b/src/js/components/common/SearchParams.tsx
@@ -26,6 +26,10 @@ type SearchParamsProps = {
 const SearchParams = ({ entries, setEntries, paramsWithDelimiter, className, suggestions }: SearchParamsProps) => {
     const itemsRef = useRef<Array<HTMLDivElement | null>>([]);
     const indexToFocusAfterDelete = useRef<number | null>(null)
+    // Tracks the option currently highlighted in whichever Autocomplete is focused.
+    // Read on Tab keydown to commit that option; replaces MUI's autoSelect, which
+    // also fired on mouse-click blur (clicking another input committed a hovered option).
+    const highlightedOptionRef = useRef<string | null>(null)
 
     const renderedRows: SearchParamsEntries = [...entries, ['', '']]
 
@@ -122,26 +126,35 @@ const SearchParams = ({ entries, setEntries, paramsWithDelimiter, className, sug
             <Autocomplete
                 className="query-param-input-key"
                 freeSolo
-                autoSelect
                 options={suggestions.keys}
                 value={key}
                 inputValue={key}
                 onInputChange={(_e, newInputValue) => updateCurrentEntryKey(newInputValue)}
                 onChange={(_e, newValue) => updateCurrentEntryKey(newValue ?? '')}
+                onHighlightChange={(_e, option) => { highlightedOptionRef.current = option }}
                 ListboxProps={{ sx: autocompleteListboxSx }}
-                renderInput={(params) => (
-                    <TextField
-                        {...params}
-                        hiddenLabel
-                        placeholder={keyPlaceholder}
-                        size="small"
-                        inputRef={el => itemsRef.current[index] = el}
-                        inputProps={{
-                            ...params.inputProps,
-                            onPaste: handleKeyPaste,
-                        }}
-                    />
-                )}
+                renderInput={(params) => {
+                    const muiKeyDown = (params.inputProps as any).onKeyDown
+                    return (
+                        <TextField
+                            {...params}
+                            hiddenLabel
+                            placeholder={keyPlaceholder}
+                            size="small"
+                            inputRef={el => itemsRef.current[index] = el}
+                            inputProps={{
+                                ...params.inputProps,
+                                onPaste: handleKeyPaste,
+                                onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+                                    if (e.key === 'Tab' && highlightedOptionRef.current) {
+                                        updateCurrentEntryKey(highlightedOptionRef.current)
+                                    }
+                                    muiKeyDown?.(e)
+                                },
+                            }}
+                        />
+                    )
+                }}
             />
         ) : (
             <TextField
@@ -173,25 +186,34 @@ const SearchParams = ({ entries, setEntries, paramsWithDelimiter, className, sug
             <Autocomplete
                 className="query-param-input-value"
                 freeSolo
-                autoSelect
                 options={valueOptions}
                 value={value}
                 inputValue={value}
                 onInputChange={(_e, newInputValue) => updateCurrentEntryValue(newInputValue)}
                 onChange={(_e, newValue) => updateCurrentEntryValue(newValue ?? '')}
+                onHighlightChange={(_e, option) => { highlightedOptionRef.current = option }}
                 ListboxProps={{ sx: autocompleteListboxSx }}
-                renderInput={(params) => (
-                    <TextField
-                        {...params}
-                        hiddenLabel
-                        placeholder="Value"
-                        size="small"
-                        inputProps={{
-                            ...params.inputProps,
-                            onPaste: handleValuePaste,
-                        }}
-                    />
-                )}
+                renderInput={(params) => {
+                    const muiKeyDown = (params.inputProps as any).onKeyDown
+                    return (
+                        <TextField
+                            {...params}
+                            hiddenLabel
+                            placeholder="Value"
+                            size="small"
+                            inputProps={{
+                                ...params.inputProps,
+                                onPaste: handleValuePaste,
+                                onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+                                    if (e.key === 'Tab' && highlightedOptionRef.current) {
+                                        updateCurrentEntryValue(highlightedOptionRef.current)
+                                    }
+                                    muiKeyDown?.(e)
+                                },
+                            }}
+                        />
+                    )
+                }}
             />
         ) : (
             <TextField

--- a/tests/components/keyboardFlow.test.tsx
+++ b/tests/components/keyboardFlow.test.tsx
@@ -46,7 +46,32 @@ describe('MuiTags keyboard behavior (preset picker)', () => {
         expect(onDelete).not.toHaveBeenCalled()
     })
 
-    test('Blur (Tab) with a highlighted suggestion calls onAdd (autoSelect)', () => {
+    test('Tab with a highlighted suggestion calls onAdd', () => {
+        const onAdd = jest.fn()
+        const onDelete = jest.fn()
+        const suggestions = [
+            { value: 'preset-a', label: 'Preset A' },
+            { value: 'preset-b', label: 'Preset B' },
+        ]
+        render(
+            <Tags
+                selected={[]}
+                suggestions={suggestions}
+                placeholderText="Add preset"
+                onAdd={onAdd}
+                onDelete={onDelete}
+            />
+        )
+        const input = screen.getByRole('combobox') as HTMLInputElement
+        fireEvent.mouseDown(input)
+        fireEvent.keyDown(input, { key: 'ArrowDown' })
+        fireEvent.keyDown(input, { key: 'Tab' })
+        expect(onAdd).toHaveBeenCalledTimes(1)
+        const added = onAdd.mock.calls[0][0]
+        expect(added[0].value).toBe('preset-a')
+    })
+
+    test('Plain blur (mouse click away) with a hovered suggestion does NOT call onAdd', () => {
         const onAdd = jest.fn()
         const onDelete = jest.fn()
         const suggestions = [
@@ -66,9 +91,7 @@ describe('MuiTags keyboard behavior (preset picker)', () => {
         fireEvent.mouseDown(input)
         fireEvent.keyDown(input, { key: 'ArrowDown' })
         fireEvent.blur(input)
-        expect(onAdd).toHaveBeenCalledTimes(1)
-        const added = onAdd.mock.calls[0][0]
-        expect(added[0].value).toBe('preset-a')
+        expect(onAdd).not.toHaveBeenCalled()
     })
 
     test('Backspace on empty input removes the last selected chip via onDelete', () => {
@@ -120,7 +143,24 @@ describe('FreeSoloTags keyboard behavior', () => {
         expect(onChange).toHaveBeenCalledWith(['alpha'])
     })
 
-    test('Blur (Tab) with a highlighted suggestion commits that suggestion (autoSelect)', () => {
+    test('Tab with a highlighted suggestion commits that suggestion', () => {
+        const onChange = jest.fn()
+        render(
+            <FreeSoloTags
+                values={[]}
+                onChange={onChange}
+                placeholderText="Add value"
+                options={['alpha', 'beta']}
+            />
+        )
+        const input = screen.getByRole('combobox') as HTMLInputElement
+        fireEvent.mouseDown(input)
+        fireEvent.keyDown(input, { key: 'ArrowDown' })
+        fireEvent.keyDown(input, { key: 'Tab' })
+        expect(onChange).toHaveBeenCalledWith(['alpha'])
+    })
+
+    test('Plain blur (mouse click away) with a hovered suggestion does NOT commit', () => {
         const onChange = jest.fn()
         render(
             <FreeSoloTags
@@ -134,7 +174,7 @@ describe('FreeSoloTags keyboard behavior', () => {
         fireEvent.mouseDown(input)
         fireEvent.keyDown(input, { key: 'ArrowDown' })
         fireEvent.blur(input)
-        expect(onChange).toHaveBeenCalledWith(['alpha'])
+        expect(onChange).not.toHaveBeenCalled()
     })
 })
 
@@ -190,7 +230,7 @@ describe('SearchParams Autocomplete keyboard behavior', () => {
         expect(lastCall).toEqual([['lang', 'en']])
     })
 
-    test('key Autocomplete: blur (Tab) with highlighted suggestion commits via autoSelect', () => {
+    test('key Autocomplete: Tab with highlighted suggestion commits the highlighted option', () => {
         const { setEntries } = renderWithSuggestions(
             [['', '']],
             { keys: ['foo', 'bar'], valuesByKey: {} }
@@ -198,12 +238,40 @@ describe('SearchParams Autocomplete keyboard behavior', () => {
         const keyInput = screen.getAllByRole('combobox')[0] as HTMLInputElement
         fireEvent.change(keyInput, { target: { value: 'fo' } })
         fireEvent.keyDown(keyInput, { key: 'ArrowDown' })
-        fireEvent.blur(keyInput)
+        fireEvent.keyDown(keyInput, { key: 'Tab' })
         const lastCall = setEntries.mock.calls.at(-1)![0]
         expect(lastCall).toEqual([['foo', '']])
     })
 
-    test('value Autocomplete: blur (Tab) with highlighted suggestion commits via autoSelect', () => {
+    test('value Autocomplete: Tab with highlighted suggestion commits the highlighted option', () => {
+        const { setEntries } = renderWithSuggestions(
+            [['lang', '']],
+            { keys: ['lang'], valuesByKey: { lang: ['en', 'fr'] } }
+        )
+        const valueInput = screen.getAllByRole('combobox')[1] as HTMLInputElement
+        fireEvent.mouseDown(valueInput)
+        fireEvent.keyDown(valueInput, { key: 'ArrowDown' })
+        fireEvent.keyDown(valueInput, { key: 'Tab' })
+        const lastCall = setEntries.mock.calls.at(-1)![0]
+        expect(lastCall).toEqual([['lang', 'en']])
+    })
+
+    test('key Autocomplete: plain blur (mouse click away) with hovered suggestion does NOT commit', () => {
+        const { setEntries } = renderWithSuggestions(
+            [['', '']],
+            { keys: ['foo', 'bar'], valuesByKey: {} }
+        )
+        const keyInput = screen.getAllByRole('combobox')[0] as HTMLInputElement
+        fireEvent.change(keyInput, { target: { value: 'fo' } })
+        setEntries.mockClear()
+        fireEvent.keyDown(keyInput, { key: 'ArrowDown' })
+        fireEvent.blur(keyInput)
+        // No Tab means the highlighted "foo" should not be committed by the blur alone.
+        const calls = setEntries.mock.calls.map(c => c[0])
+        expect(calls).not.toContainEqual([['foo', '']])
+    })
+
+    test('value Autocomplete: plain blur (mouse click away) with hovered suggestion does NOT commit', () => {
         const { setEntries } = renderWithSuggestions(
             [['lang', '']],
             { keys: ['lang'], valuesByKey: { lang: ['en', 'fr'] } }
@@ -212,8 +280,8 @@ describe('SearchParams Autocomplete keyboard behavior', () => {
         fireEvent.mouseDown(valueInput)
         fireEvent.keyDown(valueInput, { key: 'ArrowDown' })
         fireEvent.blur(valueInput)
-        const lastCall = setEntries.mock.calls.at(-1)![0]
-        expect(lastCall).toEqual([['lang', 'en']])
+        const calls = setEntries.mock.calls.map(c => c[0])
+        expect(calls).not.toContainEqual([['lang', 'en']])
     })
 })
 


### PR DESCRIPTION
## Summary
- MUI's `autoSelect` commits the highlighted option on **any** blur — so opening a dropdown with the mouse, hovering an option, then clicking another input (e.g. moving from key to value) committed the hovered option unintentionally.
- Replaced `autoSelect` across `SearchParams`, `FreeSoloTags`, and `MuiTags` with explicit Tab-keydown handling driven by `onHighlightChange`. Tab still commits the highlighted option; a plain blur (mouse click away) no longer does.
- `FreeSoloTags` now controls `inputValue` so the typed-text-on-Tab commit can clear the input after the tag is added.

## Test plan
- [x] `yarn test` — 215 tests pass, including new "plain blur does NOT commit" tests for all three components and updated Tab-keydown tests.
- [x] `yarn build` — production build succeeds.
- [ ] Manual: in the popup, open a key/value autocomplete dropdown with the mouse, hover an option, click the next input — verify the hovered option is **not** committed.
- [ ] Manual: type, arrow-down to a suggestion, press Tab — verify the highlighted suggestion is committed and focus moves to the next input.
- [ ] Manual: same flows for the preset picker (MuiTags) and delimited-value chips (FreeSoloTags).