### PR TITLE
Align popup param input caret with the placeholder/value

### DIFF
--- a/src/js/components/common/SearchParams.scss
+++ b/src/js/components/common/SearchParams.scss
@@ -7,6 +7,20 @@
     .MuiOutlinedInput-root {
         min-height: 50px;
     }
+
+    // Push all horizontal padding off the <input> element onto its wrapper.
+    // MUI's Autocomplete splits the left padding between the inputRoot (6px)
+    // and the input (8px); Chrome renders the text caret at the input's
+    // border-left rather than its content-area-start, leaving the caret
+    // visibly left of the value/placeholder. Collapsing the input's own
+    // padding-left to 0 puts the input's border-left at the same x as where
+    // text renders, so the caret and text line up.
+    .MuiAutocomplete-inputRoot {
+        padding-left: 14px !important;
+    }
+    .MuiAutocomplete-inputRoot .MuiAutocomplete-input {
+        padding-left: 0 !important;
+    }
 }
 
 .query-param-input-key {


### PR DESCRIPTION
## Summary
- The text caret in the popup's param key/value inputs sat ~8px to the left of the placeholder/value on initial focus and when clicking near the input's left edge.
- Root cause: MUI's Autocomplete splits the left padding across the `MuiAutocomplete-inputRoot` wrapper (6px) and the `<input>` element (8px). Chrome paints the caret at the input's border-left, not its content-area-start — so the caret rendered ~8px to the left of where text/placeholder starts.
- Fix: collapse the input's own left padding into the wrapper so the input's border-left coincides with where text renders, and the caret lines up.

## Test plan
- [ ] Open the popup and click into an empty "Add param" input — caret aligns with the "Add param" placeholder.
- [ ] Click on the leftmost couple of pixels inside the input box — caret still aligns.
- [ ] Type a key, value still renders at the same x as before.
- [ ] Same checks for the "Value" input on each row.